### PR TITLE
Move Google API key to env var

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: cd frontend && npm install --only=dev && npm install && npm install serve -g && npm run build && npm start
-worker: cd ./
+web1: cd frontend && npm install --only=dev && npm install && npm install serve -g && npm run build && npm start
+web2: cd ./

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,7 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
-/src/properties.js
-
 # dependencies
 /node_modules
 /.pnp

--- a/frontend/src/properties.js
+++ b/frontend/src/properties.js
@@ -1,1 +1,0 @@
-export const API_KEY = 'AIzaSyBIThhz4pzIZVP6OoV8iTKj5RnrBIvA_p8';

--- a/frontend/src/redux/sagas/restaurants/index.js
+++ b/frontend/src/redux/sagas/restaurants/index.js
@@ -3,7 +3,6 @@ import axios from 'axios';
 
 import { types, restaurantsActions } from '../../reducers/restaurants';
 import { GOOGLE_API_PATH } from '../../constants';
-import { API_KEY } from '../../../properties'
 
 const HEADER_CONTENT_TYPE = 'Content-Type';
 const HEADER_API_KEY = 'X-Goog-Api-Key';
@@ -15,7 +14,7 @@ export function* callGetRestaurants({ textQuery }) {
             { 'textQuery': textQuery },
             { headers: {
                 [HEADER_CONTENT_TYPE]: 'application/json',
-                [HEADER_API_KEY]: API_KEY,
+                [HEADER_API_KEY]: process.env.GOOGLE_API_KEY,
                 [HEADER_FIELD_MASK]: 'places.displayName,places.formattedAddress,places.id'
             }}
         );
@@ -30,7 +29,7 @@ export function* callGetRestaurantById({ restaurantId }) {
         const { data } = yield axios.get(GOOGLE_API_PATH + "places/" + restaurantId,
             { headers: {
                 [HEADER_CONTENT_TYPE]: 'application/json',
-                [HEADER_API_KEY]: API_KEY,
+                [HEADER_API_KEY]: process.env.GOOGLE_API_KEY,
                 [HEADER_FIELD_MASK]: 'id,displayName,formattedAddress'
             }}
         );


### PR DESCRIPTION
This commit deletes the Google API key hardcoded into properties.js into an env var. This fixes a temporary patch that we added in to test the application.