### PR TITLE
Add exception handler which handles invalid requests and generic exceptions

### DIFF
--- a/src/main/java/com/fryrank/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/fryrank/exception/ControllerExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.fryrank.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class ControllerExceptionHandler {
+
+    /**
+     * Exception handler for any exceptions not explicitly handled below.
+     * @param ex the exception
+     * @return map containing the exception message
+     */
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+    public Map<String, String> handleGenericException(Exception ex) {
+        return Map.of("message", ex.getMessage());
+    }
+
+    /**
+     * Exception handler for HttpMessageNotReadableException, which is thrown when null values are passed into a JSON object.
+     * @param ex the exception
+     * @return map containing the exception message
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    public Map<String, String> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        return Map.of("message", ex.getMessage());
+    }
+}


### PR DESCRIPTION
Adds an exception handler which passes the exception messages to the frontend. Provides a generic exception handler for all exceptions, as well as a specific handler for the `HttpMessageNotReadableException`, which occurs when null attributes are passed in a JSON object to the backend (example: A Create Review request includes a null title).