### PR TITLE
Add validator tests

### DIFF
--- a/src/main/java/com/fryrank/Constants.java
+++ b/src/main/java/com/fryrank/Constants.java
@@ -3,4 +3,7 @@ package com.fryrank;
 public class Constants {
 
     public static final String API_PATH = "/api";
+
+    public static final String GENERIC_VALIDATOR_ERROR_MESSAGE = "Encountered error while validating API input.";
+    public static final String REVIEW_VALIDATOR_ERRORS_OBJECT_NAME = "review";
 }

--- a/src/main/java/com/fryrank/controller/ReviewController.java
+++ b/src/main/java/com/fryrank/controller/ReviewController.java
@@ -17,7 +17,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.fryrank.Constants.*;
+import static com.fryrank.Constants.API_PATH;
+import static com.fryrank.Constants.GENERIC_VALIDATOR_ERROR_MESSAGE;
+import static com.fryrank.Constants.REVIEW_VALIDATOR_ERRORS_OBJECT_NAME;
 
 @RestController
 public class ReviewController {

--- a/src/main/java/com/fryrank/controller/ReviewController.java
+++ b/src/main/java/com/fryrank/controller/ReviewController.java
@@ -13,11 +13,11 @@ import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
-import static com.fryrank.Constants.API_PATH;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.fryrank.Constants.*;
 
 @RestController
 public class ReviewController {
@@ -45,12 +45,12 @@ public class ReviewController {
 
     @PostMapping(value = REVIEWS_URI)
     public Review addNewReviewForRestaurant(@RequestBody @NonNull final Review review) throws ValidatorException {
-        BindingResult bindingResult = new BeanPropertyBindingResult(review, "review");
+        BindingResult bindingResult = new BeanPropertyBindingResult(review, REVIEW_VALIDATOR_ERRORS_OBJECT_NAME);
         ReviewValidator validator = new ReviewValidator();
         validator.validate(review, bindingResult);
 
         if(bindingResult.hasErrors()) {
-            throw new ValidatorException(bindingResult.getAllErrors(), "Encountered error while validating API input.");
+            throw new ValidatorException(bindingResult.getAllErrors(), GENERIC_VALIDATOR_ERROR_MESSAGE);
         }
         return reviewDAL.addNewReview(review);
     }

--- a/src/test/java/com/fryrank/TestConstants.java
+++ b/src/test/java/com/fryrank/TestConstants.java
@@ -8,6 +8,8 @@ import java.util.List;
 public class TestConstants {
 
     public static final String TEST_RESTAURANT_ID = "1";
+    public static final String TEST_RESTAURANT_ID_1 = "ChIJl8BSSgfsj4ARi9qijghUAH0";
+    public static final String TEST_RESTAURANT_ID_2 = "ChIJ1wHcROHNj4ARmNwmP2PcUWw";
     public static final String TEST_REVIEW_ID_1 = "review_id_1";
     public static final String TEST_REVIEW_ID_2 = "review_id_2";
     public static final String TEST_AUTHOR_ID_1 = "author_id_1";
@@ -20,6 +22,10 @@ public class TestConstants {
     public static final String TEST_ISO_DATE_TIME_1 = "1970-01-01T00:00:00Z";
 
     public static final Review TEST_REVIEW_1 = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID, TEST_AUTHOR_ID_1, 5.0 , TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1);
+
+    public static final Review TEST_REVIEW_NULL_ISO_DATETIME = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, 5.0, TEST_TITLE_1, TEST_BODY_1, null);
+
+    public static final Review TEST_REVIEW_BAD_ISO_DATETIME = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, 5.0, TEST_TITLE_1, TEST_BODY_1, "not-a-real-date");
 
     public static final List<Review> TEST_REVIEWS = new ArrayList<>() {
         {

--- a/src/test/java/com/fryrank/controller/ReviewControllerTests.java
+++ b/src/test/java/com/fryrank/controller/ReviewControllerTests.java
@@ -17,13 +17,16 @@ import java.util.stream.Collectors;
 import static com.fryrank.TestConstants.TEST_AUTHOR_ID_1;
 import static com.fryrank.TestConstants.TEST_BODY_1;
 import static com.fryrank.TestConstants.TEST_RESTAURANT_ID;
+import static com.fryrank.TestConstants.TEST_RESTAURANT_ID_1;
+import static com.fryrank.TestConstants.TEST_RESTAURANT_ID_2;
 import static com.fryrank.TestConstants.TEST_REVIEWS;
 import static com.fryrank.TestConstants.TEST_REVIEW_1;
+import static com.fryrank.TestConstants.TEST_REVIEW_BAD_ISO_DATETIME;
+import static com.fryrank.TestConstants.TEST_REVIEW_NULL_ISO_DATETIME;
 import static com.fryrank.TestConstants.TEST_REVIEW_ID_1;
 import static com.fryrank.TestConstants.TEST_TITLE_1;
 import static com.fryrank.TestConstants.TEST_ISO_DATE_TIME_1;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
 
@@ -34,9 +37,6 @@ public class ReviewControllerTests {
 
     @InjectMocks
     ReviewController controller;
-
-    private static final String TEST_RESTAURANT_ID_1 = "ChIJl8BSSgfsj4ARi9qijghUAH0";
-    private static final String TEST_RESTAURANT_ID_2 = "ChIJ1wHcROHNj4ARmNwmP2PcUWw";
 
     // /api/reviews endpoint tests
     @Test
@@ -108,35 +108,14 @@ public class ReviewControllerTests {
         controller.addNewReviewForRestaurant(expectedReview);
     }
 
-    @Test
-    public void testAddNewReviewNullISODateTime() {
-        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, 5.0, TEST_TITLE_1, TEST_BODY_1, null);
-
-        ValidatorException exception = assertThrows(
-                ValidatorException.class, () -> controller.addNewReviewForRestaurant(expectedReview));
-
-        assertEquals("Encountered error while validating API input.\n" +
-                    "Errors:\n\tField error in object 'review' on field 'isoDateTime': rejected value [null]; codes [field.required.review.isoDateTime,field.required.isoDateTime,field.required.java.lang.String,field.required]; arguments []; default message [null]\n",
-                exception.getErrorsString()
-        );
-        assertEquals("Encountered error while validating API input.",
-                exception.getMessage());
+    @Test(expected = ValidatorException.class)
+    public void testAddNewReviewNullISODateTime() throws Exception {
+        controller.addNewReviewForRestaurant(TEST_REVIEW_NULL_ISO_DATETIME);
     }
 
-    @Test
-    public void testAddNewBadFormatISODateTime() {
-        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, 5.0, TEST_TITLE_1, TEST_BODY_1, "not-a-real-date");
-
-        ValidatorException exception = assertThrows(
-                ValidatorException.class, () -> controller.addNewReviewForRestaurant(expectedReview));
-
-        assertEquals("Encountered error while validating API input.\n" +
-                        "Errors:\n" +
-                        "\tField error in object 'review' on field 'isoDateTime': rejected value [not-a-real-date]; codes [field.invalidFormat.review.isoDateTime,field.invalidFormat.isoDateTime,field.invalidFormat.java.lang.String,field.invalidFormat]; arguments []; default message [The provided isoDateTime is not in ISO format.]\n",
-                exception.getErrorsString()
-        );
-        assertEquals("Encountered error while validating API input.",
-                exception.getMessage());
+    @Test(expected = ValidatorException.class)
+    public void testAddNewBadFormatISODateTime() throws Exception {
+        controller.addNewReviewForRestaurant(TEST_REVIEW_BAD_ISO_DATETIME);
     }
 
     // /api/reviews/aggregateInformation endpoint tests

--- a/src/test/java/com/fryrank/validator/ValidatorTests.java
+++ b/src/test/java/com/fryrank/validator/ValidatorTests.java
@@ -1,0 +1,52 @@
+package com.fryrank.validator;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ObjectError;
+
+import java.util.List;
+
+import static com.fryrank.Constants.REVIEW_VALIDATOR_ERRORS_OBJECT_NAME;
+import static com.fryrank.TestConstants.*;
+import static com.fryrank.validator.ReviewValidator.ISO_DATE_TIME_REJECTION_FORMAT_CODE;
+import static com.fryrank.validator.ReviewValidator.ISO_DATE_TIME_REJECTION_REQUIRED_CODE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ValidatorTests {
+
+    private final ReviewValidator reviewValidator = new ReviewValidator();
+
+    @Test
+    public void testValidateReviewSuccess() {
+        Errors errors = new BeanPropertyBindingResult(TEST_REVIEW_1, REVIEW_VALIDATOR_ERRORS_OBJECT_NAME);
+        reviewValidator.validate(TEST_REVIEW_1, errors);
+
+        Assert.assertFalse(errors.hasErrors());
+    }
+
+    @Test
+    public void testValidateReviewNullISODateTime() {
+        Errors errors = new BeanPropertyBindingResult(TEST_REVIEW_NULL_ISO_DATETIME, REVIEW_VALIDATOR_ERRORS_OBJECT_NAME);
+        reviewValidator.validate(TEST_REVIEW_NULL_ISO_DATETIME, errors);
+
+        Assert.assertTrue(errors.hasErrors());
+        List<ObjectError> allErrors = errors.getAllErrors();
+        Assert.assertEquals(1, allErrors.size());
+        Assert.assertEquals(allErrors.get(0).getCode(), ISO_DATE_TIME_REJECTION_REQUIRED_CODE);
+    }
+
+    @Test
+    public void testValidateReviewBadFormatISODateTime() {
+        Errors errors = new BeanPropertyBindingResult(TEST_REVIEW_BAD_ISO_DATETIME, REVIEW_VALIDATOR_ERRORS_OBJECT_NAME);
+        reviewValidator.validate(TEST_REVIEW_BAD_ISO_DATETIME, errors);
+
+        Assert.assertTrue(errors.hasErrors());
+        List<ObjectError> allErrors = errors.getAllErrors();
+        Assert.assertEquals(1, allErrors.size());
+        Assert.assertEquals(allErrors.get(0).getCode(), ISO_DATE_TIME_REJECTION_FORMAT_CODE);
+    }
+}


### PR DESCRIPTION
This commit splits out some of the validator-specific logic into its own unit tests since it makes more sense for validator-specific unit tests to do tests on the validator implementation details itself.