### PR TITLE
Replace previously-written reviews by the same author for the same restaurant

### DIFF
--- a/src/main/java/com/fryrank/dal/ReviewDALImpl.java
+++ b/src/main/java/com/fryrank/dal/ReviewDALImpl.java
@@ -3,6 +3,7 @@ package com.fryrank.dal;
 import com.fryrank.model.*;
 import lombok.NonNull;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.FindAndReplaceOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
@@ -17,7 +18,6 @@ import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
 
@@ -67,7 +67,10 @@ public class ReviewDALImpl implements ReviewDAL {
 
     @Override
     public Review addNewReview(@NonNull final Review review) {
-        mongoTemplate.save(review);
-        return review;
+        final Query query = new Query().addCriteria(Criteria.where("_id").is(review.getRestaurantId() + ":" + review.getAccountId()));
+        final FindAndReplaceOptions options = new FindAndReplaceOptions();
+        options.upsert();
+
+        return mongoTemplate.findAndReplace(query, review, options);
     }
 }

--- a/src/test/java/com/fryrank/dal/ReviewDALTests.java
+++ b/src/test/java/com/fryrank/dal/ReviewDALTests.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.mongodb.core.FindAndReplaceOptions;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
@@ -18,6 +19,8 @@ import static com.fryrank.TestConstants.TEST_REVIEW_1;
 import static com.fryrank.dal.ReviewDALImpl.RESTAURANT_ID_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
@@ -61,6 +64,8 @@ public class ReviewDALTests {
 
     @Test
     public void testAddNewReview() throws Exception {
+        when(mongoTemplate.findAndReplace(any(Query.class), eq(TEST_REVIEW_1), any(FindAndReplaceOptions.class))).thenReturn(TEST_REVIEW_1);
+
         final Review expectedReview = TEST_REVIEW_1;
         final Review actualReview = reviewDAL.addNewReview(expectedReview);
         assertEquals(expectedReview, actualReview);


### PR DESCRIPTION
- Either creates a new review with the id in format `restaurantId:accountId`, or replaces the existing review with that ID

closes https://github.com/NickPriv/FryRankBackend/issues/63