### PR TITLE
Allowing restaurant retrieval by accountId rather than just by restaurantId

### DIFF
--- a/src/main/java/com/fryrank/controller/ReviewController.java
+++ b/src/main/java/com/fryrank/controller/ReviewController.java
@@ -31,8 +31,16 @@ public class ReviewController {
     private ReviewDAL reviewDAL;
 
     @GetMapping(value = REVIEWS_URI)
-    public GetAllReviewsOutput getAllReviewsForRestaurant(@RequestParam("restaurantId") @NonNull final String restaurantId) {
-        return reviewDAL.getAllReviewsByRestaurantId(restaurantId);
+    public GetAllReviewsOutput getAllReviews(
+        @RequestParam(required = false) final String restaurantId,
+        @RequestParam(required = false) final String accountId) {
+        if (restaurantId != null) {
+            return reviewDAL.getAllReviewsByRestaurantId(restaurantId);
+        } else if (accountId != null) {
+            return reviewDAL.getAllReviewsByAccountId(accountId);
+        } else {
+            throw new NullPointerException("At least one of restaurantId and accountId must not be null.");
+        }
     }
 
     @GetMapping(value = AGGREGATE_REVIEWS_URI)

--- a/src/main/java/com/fryrank/dal/ReviewDAL.java
+++ b/src/main/java/com/fryrank/dal/ReviewDAL.java
@@ -11,6 +11,8 @@ public interface ReviewDAL {
 
     GetAllReviewsOutput getAllReviewsByRestaurantId(final String restaurantId);
 
+    GetAllReviewsOutput getAllReviewsByAccountId(final String accountId);
+
     GetAggregateReviewInformationOutput getAggregateReviewInformationForRestaurants(final List<String> restaurantIds, final AggregateReviewFilter aggregateReviewFilter);
 
     Review addNewReview(final Review review);

--- a/src/main/java/com/fryrank/dal/ReviewDALImpl.java
+++ b/src/main/java/com/fryrank/dal/ReviewDALImpl.java
@@ -25,6 +25,7 @@ import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
 public class ReviewDALImpl implements ReviewDAL {
 
     public static final String RESTAURANT_ID_KEY = "restaurantId";
+    public static final String ACCOUNT_ID_KEY = "accountId";
 
     @Autowired
     private MongoTemplate mongoTemplate;
@@ -34,6 +35,16 @@ public class ReviewDALImpl implements ReviewDAL {
         final Query query = new Query();
         final Criteria equalToRestaurantIdCriteria = Criteria.where(RESTAURANT_ID_KEY).is(restaurantId);
         query.addCriteria(equalToRestaurantIdCriteria);
+        final List<Review> reviews = mongoTemplate.find(query, Review.class);
+
+        return new GetAllReviewsOutput(reviews);
+    }
+
+    @Override
+    public GetAllReviewsOutput getAllReviewsByAccountId(@NonNull final String accountId) {
+        final Query query = new Query();
+        final Criteria equalToAccountIdCriteria = Criteria.where(ACCOUNT_ID_KEY).is(accountId);
+        query.addCriteria(equalToAccountIdCriteria);
         final List<Review> reviews = mongoTemplate.find(query, Review.class);
 
         return new GetAllReviewsOutput(reviews);

--- a/src/test/java/com/fryrank/controller/ReviewControllerTests.java
+++ b/src/test/java/com/fryrank/controller/ReviewControllerTests.java
@@ -29,6 +29,7 @@ import static com.fryrank.TestConstants.TEST_REVIEW_ID_1;
 import static com.fryrank.TestConstants.TEST_TITLE_1;
 import static com.fryrank.TestConstants.TEST_ISO_DATE_TIME_1;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
 
@@ -46,8 +47,22 @@ public class ReviewControllerTests {
         final GetAllReviewsOutput expectedOutput = new GetAllReviewsOutput(TEST_REVIEWS);
         when(reviewDAL.getAllReviewsByRestaurantId(TEST_RESTAURANT_ID)).thenReturn(expectedOutput);
 
-        final GetAllReviewsOutput actualOutput = controller.getAllReviewsForRestaurant(TEST_RESTAURANT_ID);
+        final GetAllReviewsOutput actualOutput = controller.getAllReviews(TEST_RESTAURANT_ID, null);
         assertEquals(expectedOutput, actualOutput);
+    }
+
+    @Test
+    public void testGetAllReviewsForAccount() throws Exception {
+        final GetAllReviewsOutput expectedOutput = new GetAllReviewsOutput(TEST_REVIEWS);
+        when(reviewDAL.getAllReviewsByAccountId(TEST_ACCOUNT_ID)).thenReturn(expectedOutput);
+
+        final GetAllReviewsOutput actualOutput = controller.getAllReviews(null, TEST_ACCOUNT_ID);
+        assertEquals(expectedOutput, actualOutput);
+    }
+
+    @Test
+    public void testGetAllReviewsNoParameter() throws Exception {
+        assertThrows(NullPointerException.class, () -> controller.getAllReviews(null, null));
     }
 
     @Test

--- a/src/test/java/com/fryrank/dal/ReviewDALTests.java
+++ b/src/test/java/com/fryrank/dal/ReviewDALTests.java
@@ -13,9 +13,11 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 
 import java.util.List;
 
+import static com.fryrank.TestConstants.TEST_ACCOUNT_ID;
 import static com.fryrank.TestConstants.TEST_RESTAURANT_ID;
 import static com.fryrank.TestConstants.TEST_REVIEWS;
 import static com.fryrank.TestConstants.TEST_REVIEW_1;
+import static com.fryrank.dal.ReviewDALImpl.ACCOUNT_ID_KEY;
 import static com.fryrank.dal.ReviewDALImpl.RESTAURANT_ID_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -60,6 +62,36 @@ public class ReviewDALTests {
     @Test
     public void testGetAllReviewsByRestaurantId_nullRestaurantId() {
         assertThrows(NullPointerException.class, () -> reviewDAL.getAllReviewsByRestaurantId(null));
+    }
+
+    @Test
+    public void testGetAllReviewsByAccountId_happyPath() throws Exception {
+        final Query query = new Query();
+        query.addCriteria(where(ACCOUNT_ID_KEY).is(TEST_ACCOUNT_ID));
+
+        when(mongoTemplate.find(query, Review.class)).thenReturn(TEST_REVIEWS);
+
+        final GetAllReviewsOutput expectedOutput = new GetAllReviewsOutput(TEST_REVIEWS);
+        final GetAllReviewsOutput actualOutput = reviewDAL.getAllReviewsByAccountId(TEST_ACCOUNT_ID);
+        assertEquals(actualOutput, expectedOutput);
+    }
+
+    @Test
+    public void testGetAllReviewsByAccountId_noReviews() throws Exception {
+        final Query query = new Query();
+        query.addCriteria(where(ACCOUNT_ID_KEY).is(TEST_ACCOUNT_ID));
+
+        final List<Review> expectedReviews = List.of();
+        when(mongoTemplate.find(query, Review.class)).thenReturn(expectedReviews);
+
+        final GetAllReviewsOutput expectedOutput = new GetAllReviewsOutput(expectedReviews);
+        final GetAllReviewsOutput actualOutput = reviewDAL.getAllReviewsByAccountId(TEST_ACCOUNT_ID);
+        assertEquals(actualOutput, expectedOutput);
+    }
+
+    @Test
+    public void testGetAllReviewsByAccountId_nullAccountId() {
+        assertThrows(NullPointerException.class, () -> reviewDAL.getAllReviewsByAccountId(null));
     }
 
     @Test


### PR DESCRIPTION
The get restaurants endpoint can now either take a restaurant Id or account ID. This allows you to get all reviews for a certain account.

Later, when we enable usernames, we can add logic to fetch the accountId for the username and then make the DB call.
