### PR TITLE
Change upsert user metadata endpoint to return new upserted metadata

### DIFF
--- a/src/main/java/com/fryrank/dal/UserMetadataDALImpl.java
+++ b/src/main/java/com/fryrank/dal/UserMetadataDALImpl.java
@@ -41,6 +41,7 @@ public class UserMetadataDALImpl implements UserMetadataDAL {
         final Query query = new Query().addCriteria(Criteria.where("_id").is(userMetadata.getAccountId()));
         final FindAndReplaceOptions options = new FindAndReplaceOptions();
         options.upsert();
+        options.returnNew();
 
         UserMetadata mongodbRecord =  mongoTemplate.findAndReplace(query, userMetadata, options);
         if(mongodbRecord == null) {


### PR DESCRIPTION
This commit updates the upsert user metadata endpoint that currently returns the non-current user metadata when called to return the newly upserted user metadata. This is needed because the frontend uses the user metadata returned from this endpoint to update the username on the frontend.