### PR TITLE
Refactor current getUserSettings to putUserSettings 

### DIFF
--- a/src/main/java/com/fryrank/Constants.java
+++ b/src/main/java/com/fryrank/Constants.java
@@ -5,13 +5,21 @@ public class Constants {
     public static final String API_PATH = "/api";
     public static final String ISO_DATE_TIME = "isoDateTime";
 
-    // Validator
+    // Input Validator
     public static final String GENERIC_VALIDATOR_ERROR_MESSAGE = "Encountered error while validating API input.";
     public static final String REVIEW_VALIDATOR_ERRORS_OBJECT_NAME = "review";
     public static final String USER_METADATA_VALIDATOR_ERRORS_OBJECT_NAME = "userMetadata";
     public static final String REJECTION_REQUIRED_CODE = "field.required";
     public static final String REJECTION_FORMAT_CODE = "field.invalidFormat";
 
+    // Output field names
+    public static final String USER_METADATA_OUTPUT_FIELD_NAME = "userMetadata";
+
     // MongoDB keys
     public static final String ACCOUNT_ID_KEY = "accountId";
+    public static final String PRIMARY_KEY = "_id";
+
+    // MongoDB collection names
+    public static final String REVIEW_COLLECTION_NAME = "review";
+    public static final String USER_METADATA_COLLECTION_NAME = "user-metadata";
 }

--- a/src/main/java/com/fryrank/FryRankApplication.java
+++ b/src/main/java/com/fryrank/FryRankApplication.java
@@ -32,6 +32,10 @@ public class FryRankApplication {
 						"http://fryrank-beta-stage.oxyserver.com",
 						// Local Dev Testing URL
 						"http://localhost:3000"
+				).allowedMethods(
+						"GET",
+						"POST",
+						"PUT"
 				);
 			}
 		};

--- a/src/main/java/com/fryrank/controller/UserMetadataController.java
+++ b/src/main/java/com/fryrank/controller/UserMetadataController.java
@@ -11,6 +11,7 @@ import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,6 +37,11 @@ public class UserMetadataController {
             throw new ValidatorException(bindingResult.getAllErrors(), GENERIC_VALIDATOR_ERROR_MESSAGE);
         }
         return userMetadataDAL.upsertUserMetadata(userMetadata);
+    }
+
+    @PutMapping(value=USER_METADATA_URI)
+    public UserMetadataOutput putUserMetadata(@RequestParam final String accountId, @RequestParam @NonNull final String defaultUsername) {
+        return userMetadataDAL.putUserMetadataForAccountId(accountId, defaultUsername);
     }
 
     @GetMapping(value=USER_METADATA_URI)

--- a/src/main/java/com/fryrank/dal/UserMetadataDAL.java
+++ b/src/main/java/com/fryrank/dal/UserMetadataDAL.java
@@ -4,6 +4,8 @@ import com.fryrank.model.UserMetadata;
 import com.fryrank.model.UserMetadataOutput;
 
 public interface UserMetadataDAL {
+    UserMetadataOutput putUserMetadataForAccountId(final String accountId, final String defaultUserName);
+
     UserMetadataOutput getUserMetadataForAccountId(final String accountId);
 
     UserMetadataOutput upsertUserMetadata(final UserMetadata userMetadata);

--- a/src/main/java/com/fryrank/dal/UserMetadataDALImpl.java
+++ b/src/main/java/com/fryrank/dal/UserMetadataDALImpl.java
@@ -20,7 +20,28 @@ public class UserMetadataDALImpl implements UserMetadataDAL {
     private MongoTemplate mongoTemplate;
 
     @Override
-    public UserMetadataOutput getUserMetadataForAccountId(String accountId) {
+    public UserMetadataOutput putUserMetadataForAccountId(String accountId, String defaultUserName) {
+        final Query query = new Query();
+        final Criteria equalToUserIdCriteria = Criteria.where(ACCOUNT_ID_KEY).is(accountId);
+        query.addCriteria(equalToUserIdCriteria);
+        final List<UserMetadata> userMetadata = mongoTemplate.find(query, UserMetadata.class);
+        if(!userMetadata.isEmpty()) {
+            if(userMetadata.size() > 1) {
+                // TODO(https://github.com/NickPriv/FryRankBackend/issues/76): Add warning logging statement here.
+            }
+            return new UserMetadataOutput(userMetadata.get(0).getUsername());
+        }
+        else {
+            UserMetadata newUserMetadata = new UserMetadata(
+                    accountId,
+                    defaultUserName
+            );
+            return upsertUserMetadata(newUserMetadata);
+        }
+    }
+
+    @Override
+    public UserMetadataOutput getUserMetadataForAccountId(final String accountId) {
         final Query query = new Query();
         final Criteria equalToUserIdCriteria = Criteria.where(ACCOUNT_ID_KEY).is(accountId);
         query.addCriteria(equalToUserIdCriteria);

--- a/src/main/java/com/fryrank/model/Review.java
+++ b/src/main/java/com/fryrank/model/Review.java
@@ -30,4 +30,5 @@ public class Review {
 
     private final String accountId;
 
+    private final UserMetadata userMetadata;
 }

--- a/src/main/java/com/fryrank/model/UserMetadataInitialInput.java
+++ b/src/main/java/com/fryrank/model/UserMetadataInitialInput.java
@@ -1,0 +1,11 @@
+package com.fryrank.model;
+
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document("user-metadata")
+@Data
+public class UserMetadataInitialInput {
+    private final String username;
+}

--- a/src/test/java/com/fryrank/TestConstants.java
+++ b/src/test/java/com/fryrank/TestConstants.java
@@ -25,6 +25,15 @@ public class TestConstants {
     public static final String TEST_ACCOUNT_ID_NO_USER_METADATA = "test_account_id_no_user_metadata";
     public static final String TEST_USERNAME = "testflush";
 
+    public static final UserMetadata TEST_USER_METADATA_1 = new UserMetadata(
+        TEST_ACCOUNT_ID,
+        TEST_USERNAME
+    );
+
+    public static final UserMetadataOutput TEST_USER_METADATA_OUTPUT_1 = new UserMetadataOutput(
+        TEST_USERNAME
+    );
+
     public static final Review TEST_REVIEW_1 = new Review(
         TEST_REVIEW_ID_1,
         TEST_RESTAURANT_ID,
@@ -33,7 +42,8 @@ public class TestConstants {
         TEST_TITLE_1,
         TEST_BODY_1,
         TEST_ISO_DATE_TIME_1,
-        TEST_ACCOUNT_ID
+        TEST_ACCOUNT_ID,
+        null
     );
 
     public static final Review TEST_REVIEW_NULL_ISO_DATETIME = new Review(
@@ -44,7 +54,8 @@ public class TestConstants {
         TEST_TITLE_1,
         TEST_BODY_1,
         null,
-        TEST_ACCOUNT_ID
+        TEST_ACCOUNT_ID,
+        TEST_USER_METADATA_1
     );
 
     public static final Review TEST_REVIEW_BAD_ISO_DATETIME = new Review(
@@ -55,7 +66,8 @@ public class TestConstants {
         TEST_TITLE_1,
         TEST_BODY_1,
         "not-a-real-date",
-        TEST_ACCOUNT_ID
+        TEST_ACCOUNT_ID,
+        TEST_USER_METADATA_1
     );
 
     public static final Review TEST_REVIEW_NULL_ACCOUNT_ID = new Review(
@@ -66,7 +78,8 @@ public class TestConstants {
         TEST_TITLE_1,
         TEST_BODY_1,
         TEST_ISO_DATE_TIME_1,
-        null
+        null,
+        TEST_USER_METADATA_1
     );
 
     public static final List<Review> TEST_REVIEWS = new ArrayList<>() {
@@ -80,19 +93,14 @@ public class TestConstants {
                 TEST_TITLE_2,
                 TEST_BODY_2,
                 TEST_ISO_DATE_TIME_1,
-                TEST_ACCOUNT_ID)
+                TEST_ACCOUNT_ID,
+                TEST_USER_METADATA_1)
             );
         }
     };
 
-    public static final UserMetadata TEST_USER_METADATA_1 = new UserMetadata(
-        TEST_ACCOUNT_ID,
-        TEST_USERNAME
-    );
-
-    public static final UserMetadataOutput TEST_USER_METADATA_OUTPUT_1 = new UserMetadataOutput(
-            TEST_USERNAME
-    );
+    public static final String TEST_DEFAULT_NAME = "test user name";
+    public static final UserMetadataOutput TEST_USER_METADATA_OUTPUT_WITH_DEFAULT_NAME = new UserMetadataOutput(TEST_DEFAULT_NAME);
 
     public static final UserMetadataOutput TEST_USER_METADATA_OUTPUT_EMPTY = new UserMetadataOutput(null);
 

--- a/src/test/java/com/fryrank/controller/ReviewControllerTests.java
+++ b/src/test/java/com/fryrank/controller/ReviewControllerTests.java
@@ -90,7 +90,7 @@ public class ReviewControllerTests {
 
     @Test
     public void testAddNewReviewNullReviewID() throws Exception {
-        Review expectedReview = new Review(null, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, 5.0, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID);
+        Review expectedReview = new Review(null, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, 5.0, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
 
         when(reviewDAL.addNewReview(expectedReview)).thenReturn(expectedReview);
 
@@ -101,35 +101,35 @@ public class ReviewControllerTests {
 
     @Test(expected = NullPointerException.class)
     public void testAddNewReviewNullRestaurantID() throws Exception {
-        Review expectedReview = new Review(TEST_REVIEW_ID_1, null, TEST_AUTHOR_ID_1, 5.0, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID);
+        Review expectedReview = new Review(TEST_REVIEW_ID_1, null, TEST_AUTHOR_ID_1, 5.0, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
 
         controller.addNewReviewForRestaurant(expectedReview);
     }
 
     @Test(expected = NullPointerException.class)
     public void testAddNewReviewNullAuthorID() throws Exception {
-        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, null, 5.0, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID);
+        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, null, 5.0, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
 
         controller.addNewReviewForRestaurant(expectedReview);
     }
 
     @Test(expected = NullPointerException.class)
     public void testAddNewReviewNullScore() throws Exception {
-        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, null, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID);
+        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, null, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
 
         controller.addNewReviewForRestaurant(expectedReview);
     }
 
     @Test(expected = NullPointerException.class)
     public void testAddNewReviewNullTitle() throws Exception {
-        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, 5.0, null, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID);
+        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, 5.0, null, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
 
         controller.addNewReviewForRestaurant(expectedReview);
     }
 
     @Test(expected = NullPointerException.class)
     public void testAddNewReviewNullBody() throws Exception {
-        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, 5.0, TEST_TITLE_1, null, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID);
+        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, 5.0, TEST_TITLE_1, null, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
 
         controller.addNewReviewForRestaurant(expectedReview);
     }

--- a/src/test/java/com/fryrank/controller/UserMetadataControllerTests.java
+++ b/src/test/java/com/fryrank/controller/UserMetadataControllerTests.java
@@ -11,10 +11,12 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static com.fryrank.TestConstants.TEST_ACCOUNT_ID;
+import static com.fryrank.TestConstants.TEST_DEFAULT_NAME;
 import static com.fryrank.TestConstants.TEST_USERNAME;
 import static com.fryrank.TestConstants.TEST_USER_METADATA_1;
 import static com.fryrank.TestConstants.TEST_USER_METADATA_OUTPUT_1;
 import static com.fryrank.TestConstants.TEST_USER_METADATA_OUTPUT_EMPTY;
+import static com.fryrank.TestConstants.TEST_USER_METADATA_OUTPUT_WITH_DEFAULT_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -43,6 +45,22 @@ public class UserMetadataControllerTests {
     public void testUpsertUserMetadataForNullUsername() throws Exception {
         final UserMetadata expectedUserMetadata = new UserMetadata(TEST_ACCOUNT_ID, null);
         userMetadataController.upsertUserMetadata(expectedUserMetadata);
+    }
+
+    @Test
+    public void testPutUserMetadata() throws Exception {
+        when(userMetadataDAL.putUserMetadataForAccountId(TEST_ACCOUNT_ID, TEST_DEFAULT_NAME)).thenReturn(TEST_USER_METADATA_OUTPUT_1);
+
+        final UserMetadataOutput actualUserMetadata = userMetadataController.putUserMetadata(TEST_ACCOUNT_ID, TEST_DEFAULT_NAME);
+        assertEquals(TEST_USER_METADATA_OUTPUT_1, actualUserMetadata);
+    }
+
+    @Test
+    public void testPutUserMetadataNoAccountIdParameter() throws Exception {
+        when(userMetadataDAL.putUserMetadataForAccountId(null, TEST_DEFAULT_NAME)).thenReturn(TEST_USER_METADATA_OUTPUT_WITH_DEFAULT_NAME);
+
+        final UserMetadataOutput actualUserMetadata = userMetadataController.putUserMetadata(null, TEST_DEFAULT_NAME);
+        assertEquals(TEST_USER_METADATA_OUTPUT_WITH_DEFAULT_NAME, actualUserMetadata);
     }
 
     @Test

--- a/src/test/java/com/fryrank/dal/ReviewDALTests.java
+++ b/src/test/java/com/fryrank/dal/ReviewDALTests.java
@@ -2,13 +2,17 @@ package com.fryrank.dal;
 
 import com.fryrank.model.GetAllReviewsOutput;
 import com.fryrank.model.Review;
+import org.bson.Document;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.FindAndReplaceOptions;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
@@ -19,15 +23,11 @@ import static com.fryrank.TestConstants.TEST_RESTAURANT_ID;
 import static com.fryrank.TestConstants.TEST_REVIEWS;
 import static com.fryrank.TestConstants.TEST_REVIEW_1;
 import static com.fryrank.Constants.ISO_DATE_TIME;
-import static com.fryrank.Constants.ACCOUNT_ID_KEY;
-import static com.fryrank.dal.ReviewDALImpl.RESTAURANT_ID_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.springframework.data.mongodb.core.query.Criteria.where;
-
 @RunWith(MockitoJUnitRunner.class)
 public class ReviewDALTests {
     @Mock
@@ -38,10 +38,8 @@ public class ReviewDALTests {
 
     @Test
     public void testGetAllReviewsByRestaurantId_happyPath() throws Exception {
-        final Query query = new Query();
-        query.addCriteria(where(RESTAURANT_ID_KEY).is(TEST_RESTAURANT_ID));
-
-        when(mongoTemplate.find(query, Review.class)).thenReturn(TEST_REVIEWS);
+        AggregationResults<Review> aggregationResults = new AggregationResults<>(TEST_REVIEWS, new Document());
+        when(mongoTemplate.aggregate(Mockito.any(Aggregation.class), Mockito.anyString(), Mockito.eq(Review.class))).thenReturn(aggregationResults);
 
         final GetAllReviewsOutput expectedOutput = new GetAllReviewsOutput(TEST_REVIEWS);
         final GetAllReviewsOutput actualOutput = reviewDAL.getAllReviewsByRestaurantId(TEST_RESTAURANT_ID);
@@ -50,11 +48,10 @@ public class ReviewDALTests {
 
     @Test
     public void testGetAllReviewsByRestaurantId_noReviews() throws Exception {
-        final Query query = new Query();
-        query.addCriteria(where(RESTAURANT_ID_KEY).is(TEST_RESTAURANT_ID));
-
         final List<Review> expectedReviews = List.of();
-        when(mongoTemplate.find(query, Review.class)).thenReturn(expectedReviews);
+
+        AggregationResults<Review> aggregationResults = new AggregationResults<>(expectedReviews, new Document());
+        when(mongoTemplate.aggregate(Mockito.any(Aggregation.class), Mockito.anyString(), Mockito.eq(Review.class))).thenReturn(aggregationResults);
 
         final GetAllReviewsOutput expectedOutput = new GetAllReviewsOutput(expectedReviews);
         final GetAllReviewsOutput actualOutput = reviewDAL.getAllReviewsByRestaurantId(TEST_RESTAURANT_ID);
@@ -68,10 +65,8 @@ public class ReviewDALTests {
 
     @Test
     public void testGetAllReviewsByAccountId_happyPath() throws Exception {
-        final Query query = new Query();
-        query.addCriteria(where(ACCOUNT_ID_KEY).is(TEST_ACCOUNT_ID));
-
-        when(mongoTemplate.find(query, Review.class)).thenReturn(TEST_REVIEWS);
+        AggregationResults<Review> aggregationResults = new AggregationResults<>(TEST_REVIEWS, new Document());
+        when(mongoTemplate.aggregate(Mockito.any(Aggregation.class), Mockito.anyString(), Mockito.eq(Review.class))).thenReturn(aggregationResults);
 
         final GetAllReviewsOutput expectedOutput = new GetAllReviewsOutput(TEST_REVIEWS);
         final GetAllReviewsOutput actualOutput = reviewDAL.getAllReviewsByAccountId(TEST_ACCOUNT_ID);
@@ -80,11 +75,10 @@ public class ReviewDALTests {
 
     @Test
     public void testGetAllReviewsByAccountId_noReviews() throws Exception {
-        final Query query = new Query();
-        query.addCriteria(where(ACCOUNT_ID_KEY).is(TEST_ACCOUNT_ID));
-
         final List<Review> expectedReviews = List.of();
-        when(mongoTemplate.find(query, Review.class)).thenReturn(expectedReviews);
+
+        AggregationResults<Review> aggregationResults = new AggregationResults<>(expectedReviews, new Document());
+        when(mongoTemplate.aggregate(Mockito.any(Aggregation.class), Mockito.anyString(), Mockito.eq(Review.class))).thenReturn(aggregationResults);
 
         final GetAllReviewsOutput expectedOutput = new GetAllReviewsOutput(expectedReviews);
         final GetAllReviewsOutput actualOutput = reviewDAL.getAllReviewsByAccountId(TEST_ACCOUNT_ID);

--- a/src/test/java/com/fryrank/dal/UserMetadataDALTests.java
+++ b/src/test/java/com/fryrank/dal/UserMetadataDALTests.java
@@ -15,10 +15,12 @@ import java.util.List;
 import static com.fryrank.Constants.ACCOUNT_ID_KEY;
 import static com.fryrank.TestConstants.TEST_ACCOUNT_ID;
 import static com.fryrank.TestConstants.TEST_ACCOUNT_ID_NO_USER_METADATA;
+import static com.fryrank.TestConstants.TEST_DEFAULT_NAME;
 import static com.fryrank.TestConstants.TEST_USER_METADATA_1;
 import static com.fryrank.TestConstants.TEST_USER_METADATA_LIST;
 import static com.fryrank.TestConstants.TEST_USER_METADATA_OUTPUT_1;
 import static com.fryrank.TestConstants.TEST_USER_METADATA_OUTPUT_EMPTY;
+import static com.fryrank.TestConstants.TEST_USER_METADATA_OUTPUT_WITH_DEFAULT_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -32,6 +34,38 @@ public class UserMetadataDALTests {
 
     @InjectMocks
     UserMetadataDALImpl userMetadataDAL;
+
+    @Test
+    public void testPutUserMetadataForAccountId_happyPath() throws Exception {
+        final Query query = new Query();
+        query.addCriteria(where(ACCOUNT_ID_KEY).is(TEST_ACCOUNT_ID));
+
+        when(mongoTemplate.find(query, UserMetadata.class)).thenReturn(TEST_USER_METADATA_LIST);
+
+        final UserMetadataOutput actualOutput = userMetadataDAL.putUserMetadataForAccountId(TEST_ACCOUNT_ID, TEST_DEFAULT_NAME);
+        assertEquals(actualOutput, TEST_USER_METADATA_OUTPUT_1);
+    }
+
+    @Test
+    public void testPutUserMetadataForAccountId_noUserMetadata() throws Exception {
+        final Query query = new Query();
+        query.addCriteria(where(ACCOUNT_ID_KEY).is(TEST_ACCOUNT_ID_NO_USER_METADATA));
+
+        final List<UserMetadata> expectedUserMetadata = List.of();
+        when(mongoTemplate.find(query, UserMetadata.class)).thenReturn(expectedUserMetadata);
+
+        final UserMetadataOutput actualOutput = userMetadataDAL.putUserMetadataForAccountId(TEST_ACCOUNT_ID_NO_USER_METADATA, TEST_DEFAULT_NAME);
+        assertEquals(actualOutput, TEST_USER_METADATA_OUTPUT_WITH_DEFAULT_NAME);
+    }
+
+    @Test
+    public void testPutUserMetadataForAccountId_nullAccountId() throws Exception {
+        final Query query = new Query();
+        query.addCriteria(where(ACCOUNT_ID_KEY).is(null));
+
+        final UserMetadataOutput actualOutput = userMetadataDAL.putUserMetadataForAccountId(null, TEST_DEFAULT_NAME);
+        assertEquals(actualOutput, TEST_USER_METADATA_OUTPUT_WITH_DEFAULT_NAME);
+    }
 
     @Test
     public void testGetUserMetadataForAccountId_happyPath() throws Exception {


### PR DESCRIPTION
This commit does a minor refactor of getUserSettings to putUserSettings.
This is because that with the behavior change of getUserSettings to make a
new user profile if one doesn't exist, it's now a PUT request instead of a
GET. However, we still need to expose a GET request for requests that
don't involve potential changes to the DB. Added tests for the newly added
GET request for user information