### PR TITLE
Stop accepting author ID for review and fix top n reviews endpoint

### DIFF
--- a/src/main/java/com/fryrank/dal/ReviewDALImpl.java
+++ b/src/main/java/com/fryrank/dal/ReviewDALImpl.java
@@ -93,9 +93,9 @@ public class ReviewDALImpl implements ReviewDAL {
         final Criteria idInRestaurantIdsInput = Criteria.where(RESTAURANT_ID_KEY).in(restaurantIds);
         final MatchOperation filterToRestaurantId = match(idInRestaurantIdsInput);
         final Criteria hasAccountId = Criteria.where(ACCOUNT_ID_KEY).exists(true);
-        final MatchOperation filterToUserId = match(hasAccountId);
+        final MatchOperation filterToAccountId = match(hasAccountId);
         final GroupOperation averageScoreGroupOperation = group(RESTAURANT_ID_KEY).avg("score").as("avgScore");
-        final Aggregation aggregation = newAggregation(filterToRestaurantId, filterToUserId, averageScoreGroupOperation);
+        final Aggregation aggregation = newAggregation(filterToRestaurantId, filterToAccountId, averageScoreGroupOperation);
         final AggregationResults<AggregateReviewInformation> result = mongoTemplate.aggregate(aggregation, REVIEW_COLLECTION_NAME, AggregateReviewInformation.class);
         final List<AggregateReviewInformation> aggregateReviewInformationList = result.getMappedResults();
 

--- a/src/main/java/com/fryrank/dal/ReviewDALImpl.java
+++ b/src/main/java/com/fryrank/dal/ReviewDALImpl.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,18 +40,23 @@ public class ReviewDALImpl implements ReviewDAL {
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    private static final List<AggregationOperation> AGGREGATION_OPERATIONS_FOR_PUBLIC_UISER_METADATA_COLLECTION_JOIN =
+            new ArrayList<>(Arrays.asList(
+                    LookupOperation.newLookup()
+                            .from(USER_METADATA_COLLECTION_NAME)
+                            .localField(ACCOUNT_ID_KEY)
+                            .foreignField(PRIMARY_KEY)
+                            .as(USER_METADATA_OUTPUT_FIELD_NAME),
+                    Aggregation.unwind("userMetadata")
+            ));
+
     @Override
     public GetAllReviewsOutput getAllReviewsByRestaurantId(@NonNull final String restaurantId) {
+        List<AggregationOperation> aggregationOperations = new ArrayList<>(AGGREGATION_OPERATIONS_FOR_PUBLIC_UISER_METADATA_COLLECTION_JOIN);
         final Criteria equalToRestaurantIdCriteria = Criteria.where(RESTAURANT_ID_KEY).is(restaurantId);
-        final MatchOperation filterToRestaurantId = match(equalToRestaurantIdCriteria);
+        aggregationOperations.add(match(equalToRestaurantIdCriteria));
 
-        LookupOperation lookup = LookupOperation.newLookup()
-                .from(USER_METADATA_COLLECTION_NAME)
-                .localField(ACCOUNT_ID_KEY)
-                .foreignField(PRIMARY_KEY)
-                .as(USER_METADATA_OUTPUT_FIELD_NAME);
-        AggregationOperation unwind = Aggregation.unwind("userMetadata");
-        final Aggregation aggregation = newAggregation(filterToRestaurantId, lookup, unwind);
+        final Aggregation aggregation = newAggregation(aggregationOperations);
         final AggregationResults<Review> result = mongoTemplate.aggregate(aggregation, REVIEW_COLLECTION_NAME, Review.class);
 
         return new GetAllReviewsOutput(result.getMappedResults());
@@ -57,16 +64,11 @@ public class ReviewDALImpl implements ReviewDAL {
 
     @Override
     public GetAllReviewsOutput getAllReviewsByAccountId(@NonNull final String accountId) {
+        List<AggregationOperation> aggregationOperations = new ArrayList<>(AGGREGATION_OPERATIONS_FOR_PUBLIC_UISER_METADATA_COLLECTION_JOIN);
         final Criteria equalToAccountIdCriteria = Criteria.where(ACCOUNT_ID_KEY).is(accountId);
-        final MatchOperation filterToAccountId = match(equalToAccountIdCriteria);
+        aggregationOperations.add(match(equalToAccountIdCriteria));
 
-        LookupOperation lookup = LookupOperation.newLookup()
-                .from(USER_METADATA_COLLECTION_NAME)
-                .localField(ACCOUNT_ID_KEY)
-                .foreignField(PRIMARY_KEY)
-                .as(USER_METADATA_OUTPUT_FIELD_NAME);
-        AggregationOperation unwind = Aggregation.unwind("userMetadata");
-        final Aggregation aggregation = newAggregation(filterToAccountId, lookup, unwind);
+        final Aggregation aggregation = newAggregation(aggregationOperations);
         final AggregationResults<Review> result = mongoTemplate.aggregate(aggregation, REVIEW_COLLECTION_NAME, Review.class);
 
         return new GetAllReviewsOutput(result.getMappedResults());
@@ -74,12 +76,14 @@ public class ReviewDALImpl implements ReviewDAL {
 
     @Override
     public GetAllReviewsOutput getTopMostRecentReviews(@NonNull final Integer count){
-        final Query query= new Query();
-        query.with(Sort.by(Sort.Direction.DESC, ISO_DATE_TIME));
-        query.limit(count);
-        final List<Review> reviews = mongoTemplate.find(query, Review.class);
+        List<AggregationOperation> aggregationOperations = new ArrayList<>(AGGREGATION_OPERATIONS_FOR_PUBLIC_UISER_METADATA_COLLECTION_JOIN);
+        aggregationOperations.add(sort(Sort.by(Sort.Direction.DESC, ISO_DATE_TIME)));
+        aggregationOperations.add(limit(count));
 
-        return new GetAllReviewsOutput(reviews);
+        final Aggregation aggregation = newAggregation(aggregationOperations);
+        final AggregationResults<Review> result = mongoTemplate.aggregate(aggregation, REVIEW_COLLECTION_NAME, Review.class);
+
+        return new GetAllReviewsOutput(result.getMappedResults());
     }
 
     @Override

--- a/src/main/java/com/fryrank/dal/ReviewDALImpl.java
+++ b/src/main/java/com/fryrank/dal/ReviewDALImpl.java
@@ -88,14 +88,14 @@ public class ReviewDALImpl implements ReviewDAL {
 
     @Override
     public GetAggregateReviewInformationOutput getAggregateReviewInformationForRestaurants(@NonNull final List<String> restaurantIds, @NonNull final AggregateReviewFilter aggregateReviewFilter) {
-        final Query query = new Query().addCriteria(Criteria.where(RESTAURANT_ID_KEY).in(restaurantIds));
-
         Map<String, AggregateReviewInformation> restaurantIdToAggregateReviewInformation = new HashMap<String, AggregateReviewInformation>();
 
-        final Criteria includeRestaurantIdsCriteria = Criteria.where(RESTAURANT_ID_KEY).in(restaurantIds);
-        final MatchOperation filterToRestaurantId = match(includeRestaurantIdsCriteria);
+        final Criteria idInRestaurantIdsInput = Criteria.where(RESTAURANT_ID_KEY).in(restaurantIds);
+        final MatchOperation filterToRestaurantId = match(idInRestaurantIdsInput);
+        final Criteria hasAccountId = Criteria.where(ACCOUNT_ID_KEY).exists(true);
+        final MatchOperation filterToUserId = match(hasAccountId);
         final GroupOperation averageScoreGroupOperation = group(RESTAURANT_ID_KEY).avg("score").as("avgScore");
-        final Aggregation aggregation = newAggregation(filterToRestaurantId, averageScoreGroupOperation);
+        final Aggregation aggregation = newAggregation(filterToRestaurantId, filterToUserId, averageScoreGroupOperation);
         final AggregationResults<AggregateReviewInformation> result = mongoTemplate.aggregate(aggregation, REVIEW_COLLECTION_NAME, AggregateReviewInformation.class);
         final List<AggregateReviewInformation> aggregateReviewInformationList = result.getMappedResults();
 

--- a/src/main/java/com/fryrank/dal/ReviewDALImpl.java
+++ b/src/main/java/com/fryrank/dal/ReviewDALImpl.java
@@ -40,7 +40,7 @@ public class ReviewDALImpl implements ReviewDAL {
     @Autowired
     private MongoTemplate mongoTemplate;
 
-    private static final List<AggregationOperation> AGGREGATION_OPERATIONS_FOR_PUBLIC_UISER_METADATA_COLLECTION_JOIN =
+    private static final List<AggregationOperation> AGGREGATION_OPERATIONS_FOR_PUBLIC_USER_METADATA_COLLECTION_JOIN =
             new ArrayList<>(Arrays.asList(
                     LookupOperation.newLookup()
                             .from(USER_METADATA_COLLECTION_NAME)
@@ -52,7 +52,7 @@ public class ReviewDALImpl implements ReviewDAL {
 
     @Override
     public GetAllReviewsOutput getAllReviewsByRestaurantId(@NonNull final String restaurantId) {
-        List<AggregationOperation> aggregationOperations = new ArrayList<>(AGGREGATION_OPERATIONS_FOR_PUBLIC_UISER_METADATA_COLLECTION_JOIN);
+        List<AggregationOperation> aggregationOperations = new ArrayList<>(AGGREGATION_OPERATIONS_FOR_PUBLIC_USER_METADATA_COLLECTION_JOIN);
         final Criteria equalToRestaurantIdCriteria = Criteria.where(RESTAURANT_ID_KEY).is(restaurantId);
         aggregationOperations.add(match(equalToRestaurantIdCriteria));
 
@@ -64,7 +64,7 @@ public class ReviewDALImpl implements ReviewDAL {
 
     @Override
     public GetAllReviewsOutput getAllReviewsByAccountId(@NonNull final String accountId) {
-        List<AggregationOperation> aggregationOperations = new ArrayList<>(AGGREGATION_OPERATIONS_FOR_PUBLIC_UISER_METADATA_COLLECTION_JOIN);
+        List<AggregationOperation> aggregationOperations = new ArrayList<>(AGGREGATION_OPERATIONS_FOR_PUBLIC_USER_METADATA_COLLECTION_JOIN);
         final Criteria equalToAccountIdCriteria = Criteria.where(ACCOUNT_ID_KEY).is(accountId);
         aggregationOperations.add(match(equalToAccountIdCriteria));
 
@@ -76,7 +76,7 @@ public class ReviewDALImpl implements ReviewDAL {
 
     @Override
     public GetAllReviewsOutput getTopMostRecentReviews(@NonNull final Integer count){
-        List<AggregationOperation> aggregationOperations = new ArrayList<>(AGGREGATION_OPERATIONS_FOR_PUBLIC_UISER_METADATA_COLLECTION_JOIN);
+        List<AggregationOperation> aggregationOperations = new ArrayList<>(AGGREGATION_OPERATIONS_FOR_PUBLIC_USER_METADATA_COLLECTION_JOIN);
         aggregationOperations.add(sort(Sort.by(Sort.Direction.DESC, ISO_DATE_TIME)));
         aggregationOperations.add(limit(count));
 

--- a/src/main/java/com/fryrank/model/Review.java
+++ b/src/main/java/com/fryrank/model/Review.java
@@ -15,9 +15,6 @@ public class Review {
     private final String restaurantId;
 
     @NonNull
-    private final String authorId;
-
-    @NonNull
     private final Double score;
 
     @NonNull

--- a/src/test/java/com/fryrank/TestConstants.java
+++ b/src/test/java/com/fryrank/TestConstants.java
@@ -14,8 +14,6 @@ public class TestConstants {
     public static final String TEST_RESTAURANT_ID_2 = "ChIJ1wHcROHNj4ARmNwmP2PcUWw";
     public static final String TEST_REVIEW_ID_1 = "review_id_1";
     public static final String TEST_REVIEW_ID_2 = "review_id_2";
-    public static final String TEST_AUTHOR_ID_1 = "author_id_1";
-    public static final String TEST_AUTHOR_ID_2 = "author_id_2";
     public static final String TEST_TITLE_1 = "title_1";
     public static final String TEST_TITLE_2 = "title_2";
     public static final String TEST_BODY_1 = "body_1";
@@ -37,7 +35,6 @@ public class TestConstants {
     public static final Review TEST_REVIEW_1 = new Review(
         TEST_REVIEW_ID_1,
         TEST_RESTAURANT_ID,
-        TEST_AUTHOR_ID_1,
         5.0 ,
         TEST_TITLE_1,
         TEST_BODY_1,
@@ -49,7 +46,6 @@ public class TestConstants {
     public static final Review TEST_REVIEW_NULL_ISO_DATETIME = new Review(
         TEST_REVIEW_ID_1,
         TEST_RESTAURANT_ID_1,
-        TEST_AUTHOR_ID_1,
         5.0,
         TEST_TITLE_1,
         TEST_BODY_1,
@@ -61,7 +57,6 @@ public class TestConstants {
     public static final Review TEST_REVIEW_BAD_ISO_DATETIME = new Review(
         TEST_REVIEW_ID_1,
         TEST_RESTAURANT_ID_1,
-        TEST_AUTHOR_ID_1,
         5.0,
         TEST_TITLE_1,
         TEST_BODY_1,
@@ -73,7 +68,6 @@ public class TestConstants {
     public static final Review TEST_REVIEW_NULL_ACCOUNT_ID = new Review(
         TEST_REVIEW_ID_1,
         TEST_RESTAURANT_ID,
-        TEST_AUTHOR_ID_1,
         5.0 ,
         TEST_TITLE_1,
         TEST_BODY_1,
@@ -88,7 +82,6 @@ public class TestConstants {
             add(new Review(
                 TEST_REVIEW_ID_2,
                 TEST_RESTAURANT_ID,
-                TEST_AUTHOR_ID_2,
                 7.0 ,
                 TEST_TITLE_2,
                 TEST_BODY_2,

--- a/src/test/java/com/fryrank/controller/ReviewControllerTests.java
+++ b/src/test/java/com/fryrank/controller/ReviewControllerTests.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.fryrank.TestConstants.TEST_ACCOUNT_ID;
-import static com.fryrank.TestConstants.TEST_AUTHOR_ID_1;
 import static com.fryrank.TestConstants.TEST_BODY_1;
 import static com.fryrank.TestConstants.TEST_RESTAURANT_ID;
 import static com.fryrank.TestConstants.TEST_RESTAURANT_ID_1;
@@ -90,7 +89,7 @@ public class ReviewControllerTests {
 
     @Test
     public void testAddNewReviewNullReviewID() throws Exception {
-        Review expectedReview = new Review(null, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, 5.0, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
+        Review expectedReview = new Review(null, TEST_RESTAURANT_ID_1, 5.0, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
 
         when(reviewDAL.addNewReview(expectedReview)).thenReturn(expectedReview);
 
@@ -101,35 +100,28 @@ public class ReviewControllerTests {
 
     @Test(expected = NullPointerException.class)
     public void testAddNewReviewNullRestaurantID() throws Exception {
-        Review expectedReview = new Review(TEST_REVIEW_ID_1, null, TEST_AUTHOR_ID_1, 5.0, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
-
-        controller.addNewReviewForRestaurant(expectedReview);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testAddNewReviewNullAuthorID() throws Exception {
-        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, null, 5.0, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
+        Review expectedReview = new Review(TEST_REVIEW_ID_1, null, 5.0, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
 
         controller.addNewReviewForRestaurant(expectedReview);
     }
 
     @Test(expected = NullPointerException.class)
     public void testAddNewReviewNullScore() throws Exception {
-        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, null, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
+        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, null, TEST_TITLE_1, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
 
         controller.addNewReviewForRestaurant(expectedReview);
     }
 
     @Test(expected = NullPointerException.class)
     public void testAddNewReviewNullTitle() throws Exception {
-        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, 5.0, null, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
+        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, 5.0, null, TEST_BODY_1, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
 
         controller.addNewReviewForRestaurant(expectedReview);
     }
 
     @Test(expected = NullPointerException.class)
     public void testAddNewReviewNullBody() throws Exception {
-        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, TEST_AUTHOR_ID_1, 5.0, TEST_TITLE_1, null, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
+        Review expectedReview = new Review(TEST_REVIEW_ID_1, TEST_RESTAURANT_ID_1, 5.0, TEST_TITLE_1, null, TEST_ISO_DATE_TIME_1, TEST_ACCOUNT_ID, null);
 
         controller.addNewReviewForRestaurant(expectedReview);
     }

--- a/src/test/java/com/fryrank/dal/ReviewDALTests.java
+++ b/src/test/java/com/fryrank/dal/ReviewDALTests.java
@@ -100,12 +100,11 @@ public class ReviewDALTests {
     }
 
     @Test public void testGetTopMostRecentReviews() throws Exception {
-        final Query query = new Query();
-        query.with(Sort.by(Sort.Direction.DESC, ISO_DATE_TIME));
-        query.limit(TEST_REVIEWS.size());
+        AggregationResults<Review> aggregationResults = new AggregationResults<>(TEST_REVIEWS, new Document());
+        when(mongoTemplate.aggregate(Mockito.any(Aggregation.class), Mockito.anyString(), Mockito.eq(Review.class))).thenReturn(aggregationResults);
 
-        when(mongoTemplate.find(query, Review.class)).thenReturn(TEST_REVIEWS);
+        final GetAllReviewsOutput expectedOutput = new GetAllReviewsOutput(TEST_REVIEWS);
         final GetAllReviewsOutput actualOutput = reviewDAL.getTopMostRecentReviews(TEST_REVIEWS.size());
-        assertEquals(TEST_REVIEWS.size(), actualOutput.getReviews().size());
+        assertEquals(actualOutput, expectedOutput);
     }
 }


### PR DESCRIPTION
This commit adds some fixes:
1. Stops accepting author ID for a new review which in turn stops writing it to the database. This is because this field is deprecated with the new username changes, as usernames are stored in a separate table now.
2. Top N reviews endpoint does not perform joins on the user metadata table to retrieve username information. New code has been added to fix that and refactors have been done to make this process easier for future endpoints.