### PR TITLE
Fix issue with usernames being returned as null

### DIFF
--- a/src/main/java/com/fryrank/model/PublicUserMetadata.java
+++ b/src/main/java/com/fryrank/model/PublicUserMetadata.java
@@ -4,7 +4,7 @@ import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Document("public-user-metadata")
+@Document("user-metadata")
 @Data
 public class PublicUserMetadata {
     @Id

--- a/src/main/java/com/fryrank/model/PublicUserMetadataInitialInput.java
+++ b/src/main/java/com/fryrank/model/PublicUserMetadataInitialInput.java
@@ -3,7 +3,7 @@ package com.fryrank.model;
 import lombok.Data;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Document("public-user-metadata")
+@Document("user-metadata")
 @Data
 public class PublicUserMetadataInitialInput {
     private final String username;

--- a/src/main/java/com/fryrank/model/PublicUserMetadataOutput.java
+++ b/src/main/java/com/fryrank/model/PublicUserMetadataOutput.java
@@ -3,7 +3,7 @@ package com.fryrank.model;
 import lombok.Data;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Document("public-user-metadata")
+@Document("user-metadata")
 @Data
 public class PublicUserMetadataOutput {
     private final String username;


### PR DESCRIPTION
This commit fixes an issue with the user metadata API returning null when given valid user IDs. This is because the collection name annotation was renamed to public-user-metadata when the collection name didn't change.